### PR TITLE
fix: provision API keys table for Beta account page

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -45,6 +45,7 @@ export class EricAuthStack extends Stack {
       emailVerificationsTable: database.emailVerificationsTable,
       passwordResetsTable: database.passwordResetsTable,
       refreshTokensTable: database.refreshTokensTable,
+      apiKeysTable: database.apiKeysTable,
       auditEventsTable: database.auditEventsTable,
       credentialsTable: database.credentialsTable,
       challengesTable: database.challengesTable,

--- a/cdk/lib/constructs/database.ts
+++ b/cdk/lib/constructs/database.ts
@@ -13,6 +13,7 @@ export class Database extends Construct {
   public readonly emailVerificationsTable: TableV2;
   public readonly passwordResetsTable: TableV2;
   public readonly refreshTokensTable: TableV2;
+  public readonly apiKeysTable: TableV2;
   public readonly auditEventsTable: TableV2;
   public readonly credentialsTable: TableV2;
   public readonly challengesTable: TableV2;
@@ -77,6 +78,18 @@ export class Database extends Construct {
       tableName: `${prefix}-refresh-tokens`,
       partitionKey: { name: "token_hash", type: AttributeType.STRING },
       timeToLiveAttribute: "expires_at",
+      removalPolicy,
+    });
+
+    this.apiKeysTable = new TableV2(this, "ApiKeysTable", {
+      tableName: `${prefix}-api-keys`,
+      partitionKey: { name: "key_id", type: AttributeType.STRING },
+      globalSecondaryIndexes: [
+        {
+          indexName: GSI_NAMES.USER_ID_INDEX,
+          partitionKey: { name: "user_id", type: AttributeType.STRING },
+        },
+      ],
       removalPolicy,
     });
 

--- a/cdk/lib/constructs/lambda.ts
+++ b/cdk/lib/constructs/lambda.ts
@@ -15,6 +15,7 @@ interface LambdaProps {
   emailVerificationsTable: TableV2;
   passwordResetsTable: TableV2;
   refreshTokensTable: TableV2;
+  apiKeysTable: TableV2;
   auditEventsTable: TableV2;
   credentialsTable: TableV2;
   challengesTable: TableV2;
@@ -44,6 +45,8 @@ export class Lambda extends Construct {
         EMAIL_VERIFICATIONS_TABLE_NAME: props.emailVerificationsTable.tableName,
         PASSWORD_RESETS_TABLE_NAME: props.passwordResetsTable.tableName,
         REFRESH_TOKENS_TABLE_NAME: props.refreshTokensTable.tableName,
+        API_KEYS_TABLE_NAME: props.apiKeysTable.tableName,
+        API_KEYS_USER_ID_INDEX_NAME: GSI_NAMES.USER_ID_INDEX,
         AUDIT_EVENTS_TABLE_NAME: props.auditEventsTable.tableName,
         CREDENTIALS_TABLE_NAME: props.credentialsTable.tableName,
         CHALLENGES_TABLE_NAME: props.challengesTable.tableName,
@@ -61,6 +64,7 @@ export class Lambda extends Construct {
     props.emailVerificationsTable.grantReadWriteData(this.handler);
     props.passwordResetsTable.grantReadWriteData(this.handler);
     props.refreshTokensTable.grantReadWriteData(this.handler);
+    props.apiKeysTable.grantReadWriteData(this.handler);
     props.auditEventsTable.grantReadWriteData(this.handler);
     props.credentialsTable.grantReadWriteData(this.handler);
     props.challengesTable.grantReadWriteData(this.handler);

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -89,10 +89,25 @@ test("creates password resets table with TTL", () => {
   });
 });
 
-test("creates exactly 12 DynamoDB tables", () => {
+test("creates api keys table with user id GSI", () => {
+  const template = createTestStack();
+
+  template.hasResourceProperties("AWS::DynamoDB::GlobalTable", {
+    TableName: "ericauth-test-api-keys",
+    KeySchema: [{ AttributeName: "key_id", KeyType: "HASH" }],
+    GlobalSecondaryIndexes: [
+      Match.objectLike({
+        IndexName: "userIdIndex",
+        KeySchema: [{ AttributeName: "user_id", KeyType: "HASH" }],
+      }),
+    ],
+  });
+});
+
+test("creates exactly 13 DynamoDB tables", () => {
   const template = createTestStack();
   const tables = template.findResources("AWS::DynamoDB::GlobalTable");
-  expect(Object.keys(tables).length).toBe(12);
+  expect(Object.keys(tables).length).toBe(13);
 });
 
 // --- Lambda ---
@@ -106,6 +121,7 @@ test("creates Lambda function with table name env vars", () => {
         USERS_TABLE_NAME: Match.anyValue(),
         SESSIONS_TABLE_NAME: Match.anyValue(),
         REFRESH_TOKENS_TABLE_NAME: Match.anyValue(),
+        API_KEYS_TABLE_NAME: Match.anyValue(),
         EMAIL_VERIFICATIONS_TABLE_NAME: Match.anyValue(),
         PASSWORD_RESETS_TABLE_NAME: Match.anyValue(),
         AUDIT_EVENTS_TABLE_NAME: Match.anyValue(),


### PR DESCRIPTION
## Summary
- add an `api-keys` DynamoDB table in CDK with `userIdIndex` GSI
- wire `API_KEYS_TABLE_NAME` (and index env) into Lambda configuration and grant read/write access
- extend CDK assertions to cover the new table and updated table count

## Root Cause
- Beta E2E failed after UI parity merge because `/account` now loads API key count.
- Lambda in deployed environments had no `API_KEYS_TABLE_NAME` table provisioned, producing `internal_error` (`DynamoDB query API keys failed: service error`).

## Verification
- `pnpm test -- cdk.test.ts` (RED before fix, then GREEN)
- `make synth`